### PR TITLE
Add devcontainer configuration for CUDA 12.8 environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,56 @@
+# CUDA >=12.4 is required to build for sm_100 (Blackwell)
+# Use CUDA 12.8 to match the latest cu128 PyTorch wheels.
+FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Ensure any CUDA extensions compile for Ampere, Ada, Hopper, and Blackwell GPUs.
+ENV TORCH_CUDA_ARCH_LIST="80;86;89;90;100"
+
+# Base development tools and common libraries used by the project.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        ffmpeg \
+        git \
+        libgl1-mesa-glx \
+        libxkbcommon-x11-0 \
+        ninja-build \
+        openssh-client \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        wget \
+        x11-apps \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make "python" available alongside "python3".
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+# Upgrade pip to the latest release.
+RUN python -m pip install --upgrade pip
+
+# Helpful tooling for Hugging Face artifact downloads.
+RUN pip install -U "huggingface_hub[hf_xet]"
+
+# Prefer SSH for GitHub remotes to leverage mounted host SSH keys.
+RUN git config --system url."ssh://git@github.com/".insteadOf https://github.com/
+
+# Pre-populate the GitHub host key to avoid authenticity prompts in fresh containers.
+RUN mkdir -p /etc/ssh && ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /etc/ssh/ssh_known_hosts 2>/dev/null || true
+
+# Pre-copy requirement manifests to improve Docker build caching.
+COPY requirements.txt /tmp/requirements.txt
+
+# Mark the repository workspace as safe for Git operations.
+RUN git config --global --add safe.directory /workspace
+
+WORKDIR /workspace
+
+EXPOSE 7860
+
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+  "name": "M2T2 Dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "runArgs": [
+    "--gpus", "all",
+    "--shm-size=64g",
+    "--ipc=host"
+  ],
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,readonly",
+    "source=${localEnv:HOME}/.codex,target=/root/.codex,type=bind"
+  ],
+  "containerEnv": {
+    "CODEX_HOME": "/root/.codex",
+    "TORCH_CUDA_ARCH_LIST": "80;86;89;90;100"
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [7860],
+  "postCreateCommand": "/bin/bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-toolsai.jupyter"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Refresh package index for any additional development headers required by optional extensions.
+apt-get update && apt-get install -y --no-install-recommends \
+    libavcodec-dev \
+    libavdevice-dev \
+    libavfilter-dev \
+    libavformat-dev \
+    libavutil-dev \
+    libswresample-dev \
+    libswscale-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Ensure pip itself is current inside the devcontainer runtime.
+python -m pip install --upgrade pip
+
+# Install PyTorch that matches the CUDA 12.8 toolkit baked into the image.
+python -m pip install --upgrade \
+  --index-url https://download.pytorch.org/whl/cu128 \
+  torch torchvision torchaudio
+
+# Install project Python dependencies (torch will already be satisfied).
+python -m pip install -r requirements.txt
+
+# Build and install the custom PointNet++ ops against the freshly installed torch.
+python -m pip install ./pointnet2_ops
+
+# Install the M2T2 package itself in editable mode for development.
+python -m pip install -e .
+
+# Confirm CUDA visibility inside the container (useful during post-create logs).
+python - <<'PY'
+import torch
+print("PyTorch version:", torch.__version__)
+print("CUDA available:", torch.cuda.is_available())
+if torch.cuda.is_available():
+    print("CUDA device:", torch.cuda.get_device_name(0))
+PY


### PR DESCRIPTION
## Summary
- add a CUDA 12.8 development container definition tailored for GPU workflows
- include a post-create script that installs PyTorch cu128, project requirements, and pointnet2 custom ops
- configure VS Code customizations and environment variables for the mounted workspace

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2936f6110832799774f5b5c2fa558